### PR TITLE
add_uniqueness_column

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,9 +10,9 @@
   text-align: center;  
 }
 .notice {
-  background-color: lightBlue;
+  background-color: #00c989;
 }
 
 .alert {
-  background-color: orange;
+  background-color: #ed7e00;
 }

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,6 @@
 class Category < ApplicationRecord
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
   has_many :foodstuffs
 end

--- a/app/models/foodstuff.rb
+++ b/app/models/foodstuff.rb
@@ -1,7 +1,7 @@
 class Foodstuff < ApplicationRecord
 
   with_options presence: true do
-    validates :name
+    validates :name, uniqueness: true
     validates :price
     validates :quantity
   end

--- a/db/migrate/20200226071950_add_name_tofoodstuffs.rb
+++ b/db/migrate/20200226071950_add_name_tofoodstuffs.rb
@@ -1,0 +1,5 @@
+class AddNameTofoodstuffs < ActiveRecord::Migration[5.2]
+  def change
+    add_index :foodstuffs, :name, unique: true
+  end
+end

--- a/db/migrate/20200226075952_add_name_to_categories.rb
+++ b/db/migrate/20200226075952_add_name_to_categories.rb
@@ -1,0 +1,5 @@
+class AddNameToCategories < ActiveRecord::Migration[5.2]
+  def change
+    add_index :categories, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_010556) do
+ActiveRecord::Schema.define(version: 2020_02_26_075952) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
   create_table "foodstuffs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -27,6 +28,7 @@ ActiveRecord::Schema.define(version: 2020_02_24_010556) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "category_id"
+    t.index ["name"], name: "index_foodstuffs_on_name", unique: true
   end
 
 end


### PR DESCRIPTION
# What
foodstuffsテーブルのnameカラムと、
categoriesテーブルのnameカラムに一意性制約をかけてそれぞれのvalidationに【uniqueness: true】を追記し、それぞれ同じnameキーの同バリューは保存できない様にした。